### PR TITLE
update collection name validation

### DIFF
--- a/client/src/i18n/cn/collection.ts
+++ b/client/src/i18n/cn/collection.ts
@@ -30,6 +30,10 @@ const collectionTrans = {
   dimensionMutipleWarning: 'Dimension should be 8 multiple',
   dimensionPositiveWarning: 'Dimension should be positive number',
   newBtn: 'add new field',
+  nameLengthWarning: 'Name length should be less than 256',
+  nameContentWarning: 'Name can only contain numbers, letters, and underscores',
+  nameFirstLetterWarning:
+    'Name first character must be underscore or character(a~z, A~Z)',
 
   // load dialog
   loadTitle: 'Load Collection',

--- a/client/src/i18n/en/collection.ts
+++ b/client/src/i18n/en/collection.ts
@@ -30,6 +30,10 @@ const collectionTrans = {
   dimensionMutipleWarning: 'Dimension should be 8 multiple',
   dimensionPositiveWarning: 'Dimension should be positive number',
   newBtn: 'add new field',
+  nameLengthWarning: 'Name length should be less than 256',
+  nameContentWarning: 'Name can only contain numbers, letters, and underscores',
+  nameFirstLetterWarning:
+    'Name first character must be underscore or character(a~z, A~Z)',
 
   // load dialog
   loadTitle: 'Load Collection',

--- a/client/src/pages/collections/Create.tsx
+++ b/client/src/pages/collections/Create.tsx
@@ -7,6 +7,7 @@ import { ITextfieldConfig } from '../../components/customInput/Types';
 import { rootContext } from '../../context/Root';
 import { useFormValidation } from '../../hooks/Form';
 import { formatForm } from '../../utils/Form';
+import { TypeEnum } from '../../utils/Validation';
 import CreateFields from './CreateFields';
 import {
   CollectionCreateParam,
@@ -111,11 +112,34 @@ const CreateCollection: FC<CollectionCreateProps> = ({ handleCreate }) => {
       onChange: (value: string) => handleInputChange('collection_name', value),
       variant: 'filled',
       validations: [
+        // cannot be empty
         {
           rule: 'require',
           errorText: warningTrans('required', {
             name: collectionTrans('name'),
           }),
+        },
+        // length <= 255
+        {
+          rule: 'range',
+          extraParam: {
+            max: 255,
+            type: 'string',
+          },
+          errorText: collectionTrans('nameLengthWarning'),
+        },
+        // name can only be combined with letters, number or underscores
+        {
+          rule: 'collectionName',
+          errorText: collectionTrans('nameContentWarning'),
+        },
+        // name can not start with number
+        {
+          rule: 'start',
+          extraParam: {
+            invalidTypes: [TypeEnum.number],
+          },
+          errorText: collectionTrans('nameFirstLetterWarning'),
         },
       ],
       className: classes.input,

--- a/client/src/pages/collections/Create.tsx
+++ b/client/src/pages/collections/Create.tsx
@@ -135,7 +135,7 @@ const CreateCollection: FC<CollectionCreateProps> = ({ handleCreate }) => {
         },
         // name can not start with number
         {
-          rule: 'start',
+          rule: 'firstCharacter',
           extraParam: {
             invalidTypes: [TypeEnum.number],
           },

--- a/client/src/utils/Validation.ts
+++ b/client/src/utils/Validation.ts
@@ -14,7 +14,7 @@ export type ValidType =
   | 'dimension'
   | 'multiple'
   | 'partitionName'
-  | 'start';
+  | 'firstCharacter';
 export interface ICheckMapParam {
   value: string;
   extraParam?: IExtraParam;
@@ -132,12 +132,12 @@ export const checkType = (type: TypeEnum, value: string): boolean => {
 };
 
 /**
- * check string start letter
+ * check input first character
  * @param value
  * @param invalidTypes
  * @returns whether start letter type not belongs to invalid types
  */
-export const checkStart = (param: {
+export const checkFirstCharacter = (param: {
   value: string;
   invalidTypes?: TypeEnum[];
 }): boolean => {
@@ -211,7 +211,7 @@ export const getCheckResult = (param: ICheckMapParam): boolean => {
       multipleNumber: extraParam?.multipleNumber,
     }),
     partitionName: checkPartitionName(value),
-    start: checkStart({
+    firstCharacter: checkFirstCharacter({
       value,
       invalidTypes: extraParam?.invalidTypes,
     }),

--- a/client/src/utils/Validation.ts
+++ b/client/src/utils/Validation.ts
@@ -116,6 +116,12 @@ export const checkCollectionName = (value: string): boolean => {
   return re.test(value);
 };
 
+/**
+ * check data type
+ * @param type data types, like string, number
+ * @param value
+ * @returns whether value's value is equal to param type
+ */
 export const checkType = (type: TypeEnum, value: string): boolean => {
   switch (type) {
     case TypeEnum.number:
@@ -125,6 +131,12 @@ export const checkType = (type: TypeEnum, value: string): boolean => {
   }
 };
 
+/**
+ * check string start letter
+ * @param value
+ * @param invalidTypes
+ * @returns whether start letter type not belongs to invalid types
+ */
 export const checkStart = (param: {
   value: string;
   invalidTypes?: TypeEnum[];

--- a/client/src/utils/Validation.ts
+++ b/client/src/utils/Validation.ts
@@ -13,7 +13,8 @@ export type ValidType =
   | 'collectionName'
   | 'dimension'
   | 'multiple'
-  | 'partitionName';
+  | 'partitionName'
+  | 'start';
 export interface ICheckMapParam {
   value: string;
   extraParam?: IExtraParam;
@@ -30,10 +31,17 @@ export interface IExtraParam {
   // used for dimension
   metricType?: MetricType;
   multipleNumber?: number;
+
+  // used for check start item
+  invalidTypes?: TypeEnum[];
 }
 export type CheckMap = {
   [key in ValidType]: boolean;
 };
+
+export enum TypeEnum {
+  'number' = 'number',
+}
 
 export const checkEmptyValid = (value: string): boolean => {
   return value.trim() !== '';
@@ -103,20 +111,35 @@ export const checkIpOrCIDR = (value: string): boolean => {
 };
 
 // collection name can only be combined with number, letter or _
-// name max length 255 and can't start with number
 export const checkCollectionName = (value: string): boolean => {
-  const length = value.length;
-  if (length > 254) {
-    return false;
-  }
-
-  const start = Number(value[0]);
-  if (!isNaN(start)) {
-    return false;
-  }
-
-  const re = /^[0-9,a-z,A-Z$_]+$/;
+  const re = /^[0-9,a-z,A-Z_]+$/;
   return re.test(value);
+};
+
+export const checkType = (type: TypeEnum, value: string): boolean => {
+  switch (type) {
+    case TypeEnum.number:
+      return !isNaN(Number(value));
+    default:
+      return true;
+  }
+};
+
+export const checkStart = (param: {
+  value: string;
+  invalidTypes?: TypeEnum[];
+}): boolean => {
+  const { value, invalidTypes } = param;
+  const start = value[0];
+  const types = invalidTypes || [];
+  for (let type of types) {
+    const result = checkType(type, start);
+    if (result) {
+      return false;
+    }
+  }
+
+  return true;
 };
 
 export const checkPartitionName = (value: string): boolean => {
@@ -176,6 +199,10 @@ export const getCheckResult = (param: ICheckMapParam): boolean => {
       multipleNumber: extraParam?.multipleNumber,
     }),
     partitionName: checkPartitionName(value),
+    start: checkStart({
+      value,
+      invalidTypes: extraParam?.invalidTypes,
+    }),
   };
 
   return checkMap[rule];


### PR DESCRIPTION
fix #89 

* when input is emtpy:
<img width="420" alt="empty" src="https://user-images.githubusercontent.com/20420181/123783032-863c5a00-d908-11eb-97d1-1c2c4de2ff21.png">

* when input length over 255:
<img width="423" alt="length" src="https://user-images.githubusercontent.com/20420181/123783339-d4e9f400-d908-11eb-8eae-f13f3259d72e.png">

* when input contain unsupported text:
<img width="435" alt="content" src="https://user-images.githubusercontent.com/20420181/123783098-948a7600-d908-11eb-829b-19ef5a20cd01.png">

* when input first letter is invalid:
<img width="440" alt="first letter" src="https://user-images.githubusercontent.com/20420181/123783254-c13e8d80-d908-11eb-94c5-05390ffc0126.png">


