### PR TITLE
Add default selected partition and field in option selectors

### DIFF
--- a/client/src/components/insert/Container.tsx
+++ b/client/src/components/insert/Container.tsx
@@ -116,6 +116,7 @@ const InsertContainer: FC<InsertContentProps> = ({
     setTableHeads(heads);
   }, [previewData, isContainFieldNames]);
 
+  // every time selected collection value change, partition options and default value will change
   const fetchPartition = useCallback(async () => {
     if (collectionValue) {
       const partitions = await PartitionHttp.getPartitions(collectionValue);
@@ -124,6 +125,10 @@ const InsertContainer: FC<InsertContentProps> = ({
         value: p._name,
       }));
       setPartitionOptions(partitionOptions);
+
+      // set first partition option value as default value
+      const [{ value: defaultPartitionValue }] = partitionOptions;
+      setPartitionValue(defaultPartitionValue as string);
     }
   }, [collectionValue]);
 
@@ -310,8 +315,6 @@ const InsertContainer: FC<InsertContentProps> = ({
 
   const handleCollectionChange = (name: string) => {
     setCollectionValue(name);
-    // reset partition
-    setPartitionValue('');
   };
 
   const handleNext = () => {

--- a/client/src/components/insert/Container.tsx
+++ b/client/src/components/insert/Container.tsx
@@ -126,9 +126,11 @@ const InsertContainer: FC<InsertContentProps> = ({
       }));
       setPartitionOptions(partitionOptions);
 
-      // set first partition option value as default value
-      const [{ value: defaultPartitionValue }] = partitionOptions;
-      setPartitionValue(defaultPartitionValue as string);
+      if (partitionOptions.length > 0) {
+        // set first partition option value as default value
+        const [{ value: defaultPartitionValue }] = partitionOptions;
+        setPartitionValue(defaultPartitionValue as string);
+      }
     }
   }, [collectionValue]);
 

--- a/client/src/pages/seach/VectorSearch.tsx
+++ b/client/src/pages/seach/VectorSearch.tsx
@@ -202,6 +202,12 @@ const VectorSearch = () => {
       // only vector type fields can be select
       const fieldOptions = getVectorFieldOptions(vectorFields, indexes);
       setFieldOptions(fieldOptions);
+      if (fieldOptions.length > 0) {
+        // set first option value as default field value
+        const [{ value: defaultFieldValue }] = fieldOptions;
+        setSelectedField(defaultFieldValue as string);
+      }
+
       // only non vector type fields can be advanced filter
       const filterFields = getNonVectorFieldsForFilter(nonVectorFields);
       setFilterFields(filterFields);


### PR DESCRIPTION
fix #212 

**1. select default partition (first option) when collection selected**
![import-default](https://user-images.githubusercontent.com/20420181/129509114-bea12d01-6e52-428c-994a-8582c41bb036.gif)

**2. select default field (first option) when collection selected**
![vector-search-default](https://user-images.githubusercontent.com/20420181/129509125-724d3aaf-424c-4054-b798-b967ccd1a4bc.gif)

